### PR TITLE
QA update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ matrix:
   include:
     # aliased to 5.2.17
     - php: '5.2'
+    # aliased to 5.3.29
+    - php: '5.3'
     # aliased to a recent 5.4.x version
     - php: '5.4'
+    # aliased to a recent 5.5.x version
+    - php: '5.5'
     # aliased to a recent 5.6.x version
     - php: '5.6'
       env: SNIFF=1
@@ -24,34 +28,36 @@ matrix:
     - php: '7.0'
     # aliased to a recent 7.1.x version
     - php: '7.1'
-    # aliased to a recent hhvm version
-    - php: 'hhvm'
+    # bleeding edge
+    - php: 'nightly'
 
   allow_failures:
-    - php: 'hhvm'
+    - php: 'nightly'
 
-before_script:
-  - export PHPCS_DIR=/tmp/phpcs
-  - export SNIFFS_DIR=/tmp/sniffs
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-  # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
-  # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
-  # Set install path for PHPCS sniffs.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
-  # After CodeSniffer install you should refresh your path.
-  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
-  # Install JSCS: JavaScript Code Style checker.
-  # @link http://jscs.info/
-  - if [[ "$SNIFF" == "1" ]]; then npm install -g jscs; fi
-  # Install JSHint, a JavaScript Code Quality Tool.
-  # @link http://jshint.com/docs/
-  - if [[ "$SNIFF" == "1" ]]; then npm install -g jshint; fi
-  # Pull in the WP Core jshint rules.
-  - if [[ "$SNIFF" == "1" ]]; then wget https://develop.svn.wordpress.org/trunk/.jshintrc; fi
+before_install:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_DIR=/tmp/sniffs
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    # Set install path for PHPCS sniffs.
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+    # Install JSCS: JavaScript Code Style checker.
+    # @link http://jscs.info/
+    - if [[ "$SNIFF" == "1" ]]; then npm install -g jscs; fi
+    # Install JSHint, a JavaScript Code Quality Tool.
+    # @link http://jshint.com/docs/
+    - if [[ "$SNIFF" == "1" ]]; then npm install -g jshint; fi
+    # Pull in the WP Core jshint rules.
+    - if [[ "$SNIFF" == "1" ]]; then wget https://develop.svn.wordpress.org/trunk/.jshintrc; fi
 
 
 # Run test script commands.
@@ -63,16 +69,13 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then jshint .; fi
     # Run through JavaScript Code Style checker.
     - if [[ "$SNIFF" == "1" ]]; then jscs .; fi
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --standard=./phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
 
 # Receive notifications for build results.
 # @link http://docs.travis-ci.com/user/notifications/#Email-notifications

--- a/class-debug-bar-plugin-activation-option.php
+++ b/class-debug-bar-plugin-activation-option.php
@@ -72,7 +72,6 @@ if ( ! class_exists( 'Debug_Bar_Plugin_Activation_Option' ) ) {
 			add_action( 'add_option', array( $this, 'add_default_filter' ) );
 			add_action( 'update_option', array( $this, 'add_default_filter' ) );
 
-
 			// Start buffering the output for those actions in which WP does not do so natively.
 			add_action( 'deactivate_plugin', array( $this, 'start_output_buffer' ) );
 			add_action( 'pre_uninstall_plugin', array( $this, 'start_output_buffer' ) );
@@ -232,8 +231,8 @@ if ( ! class_exists( 'Debug_Bar_Plugin_Activation_Option' ) ) {
 		 *
 		 * @static
 		 *
-		 * @param array	$defaults Entire list of supported defaults.
-		 * @param array	$options  Current options.
+		 * @param array $defaults Entire list of supported defaults.
+		 * @param array $options  Current options.
 		 *
 		 * @return array Combined and filtered options array.
 		 */

--- a/class-debug-bar-plugin-activation.php
+++ b/class-debug-bar-plugin-activation.php
@@ -120,7 +120,7 @@ if ( ! class_exists( 'Debug_Bar_Plugin_Activation' ) && class_exists( 'Debug_Bar
 				'debugBarPluginActivation',
 				array(
 					'dbpa_nonce' => wp_create_nonce( 'debug-bar-plugin-activation' ),
-					'ajaxurl'	 => admin_url( 'admin-ajax.php' ),
+					'ajaxurl'    => admin_url( 'admin-ajax.php' ),
 					'spinner'    => admin_url( 'images/wpspin_light.gif' ),
 					'errorMsg'   => __( 'An error occurred', 'debug-bar-plugin-activation' ),
 				)

--- a/debug-bar-plugin-activation.php
+++ b/debug-bar-plugin-activation.php
@@ -52,10 +52,14 @@ if ( ! function_exists( 'db_plugin_activation_has_parent_plugin' ) ) {
 			deactivate_plugins( DB_PA_BASENAME, false, is_network_admin() );
 
 			// Add to recently active plugins list.
+			$insert = array(
+				DB_PA_BASENAME => time(),
+			);
+
 			if ( ! is_network_admin() ) {
-				update_option( 'recently_activated', ( array( DB_PA_BASENAME => time() ) + (array) get_option( 'recently_activated' ) ) );
+				update_option( 'recently_activated', ( $insert + (array) get_option( 'recently_activated' ) ) );
 			} else {
-				update_site_option( 'recently_activated', ( array( DB_PA_BASENAME => time() ) + (array) get_site_option( 'recently_activated' ) ) );
+				update_site_option( 'recently_activated', ( $insert + (array) get_site_option( 'recently_activated' ) ) );
 			}
 
 			// Prevent trying again on page reload.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,29 +16,58 @@
 
 
 	<!-- ##### WordPress sniffs #####-->
-	<rule ref="WordPress">
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
-		<exclude name="WordPress.VIP.RestrictedFunctions.error_log" />
+	<rule ref="WordPress"/>
+
+
+	<!-- ##### Customizations #####-->
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="debug-bar-plugin-activation" />
+		</properties>
 	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="Debug_Bar_Plugin_Activation,db_plugin_activation,DB_PA" />
+		</properties>
+
+		<!-- Exclude the test plugin files as they are not part of the distribute plugin. -->
+		<exclude-pattern>*/tests/testfiles/*.php</exclude-pattern>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 supported by the Debug Bar extension. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="3.8" />
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.8" />
+		</properties>
+	</rule>
+
+
+	<!-- ##### Exlusions #####-->
 	
-	
-	<!-- exclude the 'empty' index files from some documentation checks -->
+	<!-- Exclude the test files from the trigger_error() function check as that's the whole point. -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error">
+		<exclude-pattern>*/tests/testfiles/*.php</exclude-pattern>
+	</rule>
+
+	<!-- Exclude the 'empty' index files from some documentation checks. -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
 		<exclude-pattern>*/index.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.InlineComment.SpacingAfter">
 		<exclude-pattern>*/index.php</exclude-pattern>
-	</rule>
-
-	<!-- exclude the test files from some documentation checks -->
-	<rule ref="Squiz.Commenting.FileComment">
-		<exclude-pattern>testfiles/*.php</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.BlockComment">
-		<exclude-pattern>testfiles/*.php</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.InlineComment">
-		<exclude-pattern>testfiles/*.php</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,14 @@
 <ruleset name="Debug Bar Plugin Activation">
 	<description>The code standard for Debug Bar Plugin Activation is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>

--- a/tests/testfiles/test-plugin-activation-4/testfile-plugin-activation-4.php
+++ b/tests/testfiles/test-plugin-activation-4/testfile-plugin-activation-4.php
@@ -1,9 +1,13 @@
 <?php
+/**
+ * Plugin Name: Testing Debug Bar Plugin Activation 4.
+ * Description: Testing Debug Bar Plugin Activation 4.
+ * Version:     1.0
+ *
+ * @package     WordPress\Plugins\Debug Bar Plugin Activation
+ * @subpackage  Test
+ */
+
 /*
-Plugin Name: Testing Debug Bar Plugin Activation 4.
-Description: Testing Debug Bar Plugin Activation 4.
-Version:     1.0
-*/
-
-
-// This 'plugin' is just to test whether uninstall errors are caught when an uninstall.php file is used.
+ * This 'plugin' is just to test whether uninstall errors are caught when an uninstall.php file is used.
+ */

--- a/tests/testfiles/test-plugin-activation-4/uninstall.php
+++ b/tests/testfiles/test-plugin-activation-4/uninstall.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * Code used when the plugin is removed (not just deactivated but actively deleted by the WordPress Admin).
+ *
+ * @package    WordPress\Plugins\Debug Bar Plugin Activation
+ * @subpackage Test
  */
 
 if ( ! current_user_can( 'activate_plugins' ) || ( ! defined( 'ABSPATH' ) || ! defined( 'WP_UNINSTALL_PLUGIN' ) ) ) {

--- a/tests/testfiles/testfile-plugin-activation-1.php
+++ b/tests/testfiles/testfile-plugin-activation-1.php
@@ -1,10 +1,12 @@
 <?php
-/*
-Plugin Name: Testing Debug Bar Plugin Activation 1.
-Description: Testing Debug Bar Plugin Activation 1.
-Version:     1.0
-*/
-
+/**
+ * Plugin Name: Testing Debug Bar Plugin Activation 1.
+ * Description: Testing Debug Bar Plugin Activation 1.
+ * Version:     1.0
+ *
+ * @package     WordPress\Plugins\Debug Bar Plugin Activation
+ * @subpackage  Test
+ */
 
 if ( ! function_exists( 'testfile_pa1_activate' ) ) {
 	/**

--- a/tests/testfiles/testfile-plugin-activation-2.php
+++ b/tests/testfiles/testfile-plugin-activation-2.php
@@ -1,10 +1,12 @@
 <?php
-/*
-Plugin Name: Testing Debug Bar Plugin Activation 2.
-Description: Testing Debug Bar Plugin Activation 2.
-Version:     1.0
-*/
-
+/**
+ * Plugin Name: Testing Debug Bar Plugin Activation 2.
+ * Description: Testing Debug Bar Plugin Activation 2.
+ * Version:     1.0
+ *
+ * @package     WordPress\Plugins\Debug Bar Plugin Activation
+ * @subpackage  Test
+ */
 
 if ( ! function_exists( 'testfile_pa2_activate' ) ) {
 	/**

--- a/tests/testfiles/testfile-plugin-activation-3.php
+++ b/tests/testfiles/testfile-plugin-activation-3.php
@@ -1,10 +1,12 @@
 <?php
-/*
-Plugin Name: Testing Debug Bar Plugin Activation 3.
-Description: Testing Debug Bar Plugin Activation 3.
-Version:     1.0
-*/
-
+/**
+ * Plugin Name: Testing Debug Bar Plugin Activation 3.
+ * Description: Testing Debug Bar Plugin Activation 3.
+ * Version:     1.0
+ *
+ * @package     WordPress\Plugins\Debug Bar Plugin Activation
+ * @subpackage  Test
+ */
 
 if ( ! function_exists( 'testfile_pa3_deactivate' ) ) {
 	/**


### PR DESCRIPTION
### Update Travis build script
* Include PHP 5.3, 5.5 and nightly in the build matrix and remove HHVM.
* Use `before_install` rather than `before_script` to better distinguish between failed install or failed build.
* Use the PHPCS `2.9` branch until the external standards are compatible with PHPCS 3.x.
* Use the WPCS `develop` branch to benefit from the latest sniffs.
* Move the standard PHPCS command line arguments to the custom ruleset.
* Show PHPCS warnings, but don't fail the build on it.

### Update the PHPCS ruleset for WPCS 0.12.0
* Remove some exclusions and make one more specific.
* Verify that the correct text domain is being used.
* Verify that everything in the global namespace is prefixed correctly.
* Verify that no WP deprecated functions or classes are used.

### Minor codestyle fixes